### PR TITLE
Update glibc version

### DIFF
--- a/docker/Dockerfile.ubi.amd64
+++ b/docker/Dockerfile.ubi.amd64
@@ -24,6 +24,7 @@ ARG VAULT_VERSION=1.14.8 \
 WORKDIR /
 RUN set -eux; \
     microdnf update -y --nodocs --refresh 1>/dev/null 2>&1 && \
+    microdnf update -y glibc && \
     microdnf install -y --nodocs ca-certificates shadow-utils gnupg openssl libcap wget tzdata unzip gzip tar 1>/dev/null 2>&1 && \
     microdnf upgrade -y --nodocs --setopt=install_weak_deps=0 --disableplugin=subscription-manager krb5-libs 1>/dev/null 2>&1 && \
     found=''; \


### PR DESCRIPTION
### CVE description
When the assert() function in the GNU C Library versions 2.13 to 2.40 fails, it does not allocate enough space for the assertion failure message string and size information, which may lead to a buffer overflow if the message string size aligns to page size.

### references 
[97](https://github.com/open-horizon/vault-plugin-auth-openhorizon/issues/97)