### PR TITLE
adding health check to dockerfile

### DIFF
--- a/docker/Dockerfile.ubi.amd64
+++ b/docker/Dockerfile.ubi.amd64
@@ -109,3 +109,5 @@ USER vault
 # By default you'll get a single-node development server that stores everything
 # in RAM and bootstraps itself. Don't use this configuration for production.
 CMD ["server", "-dev"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD grep -q entrypoint.sh /proc/1/comm || exit 1


### PR DESCRIPTION
One of the important security triads is availability. Adding HEALTHCHECK instruction to your container image ensures that the docker engine periodically checks the running container instances against that instruction to ensure that the instances are still working

![image](https://github.com/user-attachments/assets/87967fd3-2db5-4f49-94d3-2e2355a565c9)
