### PR TITLE
Switch kubectl download to dl.k8s.io

### DIFF
--- a/docker/Dockerfile.ubi.amd64
+++ b/docker/Dockerfile.ubi.amd64
@@ -89,7 +89,7 @@ EXPOSE 8200
 
 # For production derivatives of this container, you shoud add the IPC_LOCK
 # capability so that Vault can mlock memory.
-RUN curl -4LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
+RUN curl -4LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin
 


### PR DESCRIPTION
### PR description
Update Dockerfile to pull kubectl v1.33.2 (was v1.31.0)